### PR TITLE
Updates to menu button in mobile and app header, space on some buttons

### DIFF
--- a/lib/components/app_header.ex
+++ b/lib/components/app_header.ex
@@ -18,7 +18,7 @@ defmodule Palette.Components.AppHeader do
       <!-- Header Items -->
       <div class="flex w-full items-center justify-between">
         <!-- Left: Sidebar Toggle Button -->
-        <div class="block md:hidden h-7 w-7">
+        <div class="h-7 w-7">
           <button
             class="menu-toggle ml-0.5 flex h-7 w-7 flex-col justify-center space-y-1.5 text-primary outline-none focus:outline-none dark:text-accent-light/80"
             x-bind:class="$store.global.isSidebarExpanded && 'active'"

--- a/lib/components/app_header.ex
+++ b/lib/components/app_header.ex
@@ -18,7 +18,7 @@ defmodule Palette.Components.AppHeader do
       <!-- Header Items -->
       <div class="flex w-full items-center justify-between">
         <!-- Left: Sidebar Toggle Button -->
-        <div class="h-7 w-7">
+        <div class="block md:hidden h-7 w-7">
           <button
             class="menu-toggle ml-0.5 flex h-7 w-7 flex-col justify-center space-y-1.5 text-primary outline-none focus:outline-none dark:text-accent-light/80"
             x-bind:class="$store.global.isSidebarExpanded && 'active'"
@@ -30,7 +30,7 @@ defmodule Palette.Components.AppHeader do
           </button>
         </div>
         <!-- Right: Header buttons -->
-        <div class="-mr-1.5 flex items-center space-x-2">
+        <div class="-mr-1.5 flex items-center space-x-2 md:ml-auto">
           <!-- Mobile Search Toggle -->
           <button
             @click="$store.global.isSearchbarActive = !$store.global.isSearchbarActive"

--- a/lib/components/breadcrumb/breadcrumb.ex
+++ b/lib/components/breadcrumb/breadcrumb.ex
@@ -22,10 +22,8 @@ defmodule Palette.Components.Breadcrumb do
   defp render(assigns) do
     ~H"""
     <div class="flex items-center justify-between py-5 lg:py-6">
-      <div class="flex items-center space-x-1">
-        <h2 class="text-xl font-medium text-slate-800 dark:text-navy-50 lg:text-2xl">
-          <%= @title %>
-        </h2>
+      <div class="flex flex-col justify-center items-start space-y-1">
+        <h1 class="text-xl font-semibold text-gray-900 dark:text-navy-50 sm:text-2xl"><%= @title %></h1>
         <div class="hidden h-full py-1 sm:flex">
           <div class="h-full w-px bg-slate-300 dark:bg-navy-600"></div>
         </div>

--- a/lib/components/breadcrumb/breadcrumb.ex
+++ b/lib/components/breadcrumb/breadcrumb.ex
@@ -37,7 +37,7 @@ defmodule Palette.Components.Breadcrumb do
               navigate={step.path}
             >
               <i :if={step.icon} class={step.icon}></i>
-              <%=step.label%>
+              <%= step.label %>
             </.link>
 
             <i :if={is_nil(step.path) && step.icon} class={step.icon}></i>

--- a/lib/components/breadcrumb/breadcrumb.ex
+++ b/lib/components/breadcrumb/breadcrumb.ex
@@ -23,7 +23,9 @@ defmodule Palette.Components.Breadcrumb do
     ~H"""
     <div class="flex items-center justify-between py-5 lg:py-6">
       <div class="flex flex-col justify-center items-start space-y-1">
-        <h1 class="text-xl font-semibold text-gray-900 dark:text-navy-50 sm:text-2xl"><%= @title %></h1>
+        <h1 class="text-xl font-semibold text-gray-900 dark:text-navy-50 sm:text-2xl">
+          <%= @title %>
+        </h1>
         <div class="hidden h-full py-1 sm:flex">
           <div class="h-full w-px bg-slate-300 dark:bg-navy-600"></div>
         </div>

--- a/lib/components/breadcrumb/breadcrumb.ex
+++ b/lib/components/breadcrumb/breadcrumb.ex
@@ -37,7 +37,7 @@ defmodule Palette.Components.Breadcrumb do
               navigate={step.path}
             >
               <i :if={step.icon} class={step.icon}></i>
-              <%= step.label %>
+              <%=step.label%>
             </.link>
 
             <i :if={is_nil(step.path) && step.icon} class={step.icon}></i>
@@ -57,7 +57,7 @@ defmodule Palette.Components.Breadcrumb do
           <li>
             <div class="flex items-center space-x-1.5">
               <i :if={@last.icon} class={@last.icon}></i>
-              <%= @last.label %>
+              <span><%= @last.label %></span>
             </div>
           </li>
         </ul>

--- a/lib/components/page_header.ex
+++ b/lib/components/page_header.ex
@@ -21,10 +21,10 @@ defmodule Palette.Components.PageHeader do
     <div class="block justify-between items-center p-4 mt-2 mb-3 bg-white rounded-2xl shadow-md shadow-gray-200 lg:p-5 sm:flex">
       <div class="mb-1 w-full">
         <div class="mb-4">
-          <Breadcrumb.breadcrumb steps={@breadcrumb} title="asdf" />
-          <%= if @show_title do %>
+          <Breadcrumb.breadcrumb steps={@breadcrumb} title={@title} />
+          <%!-- <%= if @show_title do %>
             <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl"><%= @title %></h1>
-          <% end %>
+          <% end %> --%>
         </div>
         <div class="sm:flex">
           <%= if @show_search do %>

--- a/lib/components/sidebar_profile.ex
+++ b/lib/components/sidebar_profile.ex
@@ -44,7 +44,7 @@ defmodule Palette.Components.SidebarProfile do
             <div class="mt-3 px-4">
               <.link
                 href={@profile_path}
-                class="group flex items-center space-x-3 py-2 px-4 tracking-wide outline-none transition-all hover:bg-slate-100 focus:bg-slate-100 dark:hover:bg-navy-600 dark:focus:bg-navy-600"
+                class="group flex items-center space-x-3 py-2 px-4 tracking-wide outline-none transition-all hover:bg-slate-100 focus:bg-slate-100 dark:hover:bg-navy-600 dark:focus:bg-navy-600 rounded-md mb-2"
               >
                 <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-warning text-white">
                   <svg

--- a/lib/components/sign_in.ex
+++ b/lib/components/sign_in.ex
@@ -11,7 +11,7 @@ defmodule Palette.Components.SignIn do
     <main class="grid w-full grow grid-cols-1 place-items-center">
       <div class="w-full max-w-[26rem] p-4 sm:px-5">
         <div class="text-center">
-          <img class="mx-auto h-16 w-16" src="/images/logo-300.png" alt="logo" />
+          <img class="mx-auto h-16 w-24" src="/images/logo-300.png" alt="logo" />
           <div class="mt-4">
             <h2 class="text-2xl font-semibold text-slate-600 dark:text-navy-100">
               <%= @title %>

--- a/test/components/breadcrumb_test.exs
+++ b/test/components/breadcrumb_test.exs
@@ -7,7 +7,9 @@ defmodule Palette.Components.BreadcrumbTest do
 
   alias Palette.Components.Breadcrumb.Step
 
-  setup(do: [assigns: %{title: "Testing", steps: [%Step{label: "Home"}, %Step{label: "Another"}]}])
+  setup(
+    do: [assigns: %{title: "Testing", steps: [%Step{label: "Home"}, %Step{label: "Another"}]}]
+  )
 
   describe "breadcrumb/1" do
     test "breadcrumb will be render properly", %{assigns: assigns} do

--- a/test/components/breadcrumb_test.exs
+++ b/test/components/breadcrumb_test.exs
@@ -7,11 +7,11 @@ defmodule Palette.Components.BreadcrumbTest do
 
   alias Palette.Components.Breadcrumb.Step
 
-  setup(do: [assigns: %{steps: [%Step{label: "Home"}, %Step{label: "Another"}]}])
+  setup(do: [assigns: %{title: "Testing", steps: [%Step{label: "Home"}, %Step{label: "Another"}]}])
 
   describe "breadcrumb/1" do
     test "breadcrumb will be render properly", %{assigns: assigns} do
-      h = ~H(<.breadcrumb title="Testing" steps={@steps} />)
+      h = ~H(<.breadcrumb title={@title} steps={@steps} />)
       assert rendered_to_string(h) =~ ~s(>Another<)
     end
   end


### PR DESCRIPTION
The goal of this PR is to clean up a few spacing and responsive issues I noticed.

- The main change is hiding the `bars` icon on desktop screens. I love our sidebar animations and feel like having two nav buttons is kinda confusing. That being said on mobile we need to have that button show. So I just changed that.

- The page header looked odd to me with a header directly next to the breadcrumbs so I simply move the breadcrumbs down to below the page header title and moved that `h1` into the breadcrumbs component for now. I commented out the main title for now just so we can see how this behaves in different apps before totally committing to it.

- On the sign in page I made the logo image rectangular instead of square. I would like to add a new component here that is more dynamic based on how the users want their logo to show up, but this should at least keep squared images from stretching (if not then we can fix that) and rectangular images from showing squished. I could see needing to play with this a bit to get it perfect.

- Lastly, I just put some spacing below the profile link in the sidebar avatar and rounded off that component to match the rest of the UI.